### PR TITLE
Follow-up: fix DID DM match + preserve display_name on import

### DIFF
--- a/bsky_cli/context_cmd.py
+++ b/bsky_cli/context_cmd.py
@@ -167,15 +167,19 @@ def _fetch_dm_context_from_db(conn, *, my_did: str, target_did: str, limit: int)
 
 
 def _fetch_dm_context(pds: str, jwt: str, account_handle: str, target_handle: str, limit: int) -> list[dict]:
-    target_handle = (target_handle or "").lstrip("@").lower()
+    target_handle = (target_handle or "").strip().lstrip("@").lower()
     if not target_handle:
         return []
+
+    target_is_did = target_handle.startswith("did:")
 
     convos = get_dm_conversations(pds, jwt, limit=50)
     convo = None
     for c in convos:
         for m in c.get("members", []) or []:
-            if (m.get("handle") or "").lower() == target_handle:
+            m_handle = (m.get("handle") or "").lower()
+            m_did = (m.get("did") or "").lower()
+            if (target_is_did and m_did == target_handle) or (not target_is_did and m_handle == target_handle):
                 convo = c
                 break
         if convo:

--- a/bsky_cli/storage/db.py
+++ b/bsky_cli/storage/db.py
@@ -255,8 +255,8 @@ def import_interlocutors_json(conn: sqlite3.Connection, *, overwrite: bool = Fal
         if existing and not overwrite:
             # keep manual notes/tags as-is; update basic fields + counts, and append interactions if new
             conn.execute(
-                "UPDATE actors SET handle=COALESCE(?, handle), display_name=COALESCE(?, display_name), first_seen=COALESCE(NULLIF(?,''), first_seen), last_interaction=COALESCE(NULLIF(?,''), last_interaction), total_count=MAX(total_count, ?) WHERE did=?",
-                (handle, display_name, first_seen, last_interaction, total_count, did),
+                "UPDATE actors SET handle=COALESCE(NULLIF(?,''), handle), display_name=COALESCE(NULLIF(?,''), display_name), first_seen=COALESCE(NULLIF(?,''), first_seen), last_interaction=COALESCE(NULLIF(?,''), last_interaction), total_count=MAX(total_count, ?) WHERE did=?",
+                (handle or "", display_name or "", first_seen, last_interaction, total_count, did),
             )
         else:
             conn.execute(

--- a/tests/test_context_dm_match_did.py
+++ b/tests/test_context_dm_match_did.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+
+def test_fetch_dm_context_matches_did_targets(monkeypatch):
+    from bsky_cli import context_cmd
+
+    # Fake convo list: member has DID+handle
+    fake_convos = [
+        {
+            "id": "convo1",
+            "members": [
+                {"did": "did:plc:target", "handle": "target.example", "displayName": "Target"},
+                {"did": "did:me", "handle": "echo.0mg.cc", "displayName": "Echo"},
+            ],
+        }
+    ]
+
+    fake_messages = [
+        {"sender": {"did": "did:plc:target"}, "text": "hi", "sentAt": "2026-02-10T00:00:00Z"},
+    ]
+
+    monkeypatch.setattr(context_cmd, "get_dm_conversations", lambda pds, jwt, limit=50: fake_convos)
+    monkeypatch.setattr(context_cmd, "get_dm_messages", lambda pds, jwt, convo_id, limit=1: fake_messages)
+
+    out = context_cmd._fetch_dm_context(
+        "https://pds",
+        "jwt",
+        "echo.0mg.cc",
+        "did:plc:target",
+        1,
+    )
+
+    assert out and out[0]["text"] == "hi"

--- a/tests/test_import_interlocutors_preserve_display_name.py
+++ b/tests/test_import_interlocutors_preserve_display_name.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from bsky_cli.storage import db as dbmod
+
+
+def test_import_interlocutors_does_not_clear_existing_display_name(monkeypatch, tmp_path: Path):
+    legacy = tmp_path / "interlocutors.json"
+    legacy.write_text(
+        json.dumps(
+            {
+                "did:plc:abc": {
+                    "did": "did:plc:abc",
+                    "handle": "alice.example",
+                    # display_name is missing/blank in legacy
+                    "tags": [],
+                    "interactions": [],
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(dbmod, "INTERLOCUTORS_JSON", legacy)
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    dbmod.ensure_schema(conn)
+
+    conn.execute(
+        "INSERT INTO actors(did, handle, display_name) VALUES (?,?,?)",
+        ("did:plc:abc", "alice.example", "Alice"),
+    )
+    conn.commit()
+
+    dbmod.import_interlocutors_json(conn, overwrite=False)
+
+    row = conn.execute("SELECT display_name FROM actors WHERE did='did:plc:abc'").fetchone()
+    assert row["display_name"] == "Alice"


### PR DESCRIPTION
Addresses Codex inline review comments missed previously:

- context: support `bsky context did:...` by matching DM convo members by `did` when the target input is a DID.
- storage: prevent legacy import from clearing an existing `actors.display_name` to '' when overwrite=false.

Includes regression tests for both.
