### PR TITLE
Fix organic posting: retry OpenRouter 429 with exponential backoff

### DIFF
--- a/bsky_cli/http.py
+++ b/bsky_cli/http.py
@@ -22,6 +22,12 @@ def get_limiter() -> RateLimiter:
 class _RateLimitedRequests:
     """Drop-in subset of requests module with rate limiting."""
 
+    # Proxy exception classes so except clauses work
+    ConnectionError = _requests.ConnectionError
+    Timeout = _requests.Timeout
+    HTTPError = _requests.HTTPError
+    RequestException = _requests.RequestException
+
     @staticmethod
     def get(url: str, **kwargs):
         get_limiter().wait_if_needed()

--- a/tests/test_organic_retry.py
+++ b/tests/test_organic_retry.py
@@ -61,3 +61,66 @@ def test_generate_post_with_llm_returns_none_after_429_retries(monkeypatch):
 
     assert out is None
     assert calls["n"] == 3
+
+
+def test_generate_post_with_llm_no_retry_on_permanent_error(monkeypatch):
+    """Permanent errors like 401/400 should NOT be retried (PR #17 review fix)."""
+    monkeypatch.setattr(organic, "load_from_pass", lambda _p: {"OPENROUTER_API_KEY": "k"})
+    monkeypatch.setattr(organic, "get", lambda *_a, **_k: 2)
+
+    calls = {"n": 0}
+
+    def _post(*args, **kwargs):
+        calls["n"] += 1
+        return _Resp(401, {"error": "unauthorized"})
+
+    monkeypatch.setattr(organic.requests, "post", _post)
+    monkeypatch.setattr(organic, "sleep", lambda _s: None)
+
+    out = organic.generate_post_with_llm("activités", _minimal_source(), "guidelines")
+
+    assert out is None
+    # Should fail on first attempt without retrying
+    assert calls["n"] == 1, "Permanent errors must not trigger retries"
+
+
+def test_generate_post_with_llm_retries_on_connection_error(monkeypatch):
+    """Transient network errors should be retried."""
+    monkeypatch.setattr(organic, "load_from_pass", lambda _p: {"OPENROUTER_API_KEY": "k"})
+    monkeypatch.setattr(organic, "get", lambda *_a, **_k: 2)
+
+    calls = {"n": 0}
+
+    def _post(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise organic.requests.ConnectionError("connection reset")
+        return _Resp(200, {"choices": [{"message": {"content": '{"text":"recovered"}'}}]})
+
+    monkeypatch.setattr(organic.requests, "post", _post)
+    monkeypatch.setattr(organic, "sleep", lambda _s: None)
+
+    out = organic.generate_post_with_llm("activités", _minimal_source(), "guidelines")
+
+    assert out == {"text": "recovered"}
+    assert calls["n"] == 2
+
+
+def test_generate_post_with_llm_no_retry_on_json_parse_error(monkeypatch):
+    """JSON parse errors (malformed LLM output) should NOT be retried."""
+    monkeypatch.setattr(organic, "load_from_pass", lambda _p: {"OPENROUTER_API_KEY": "k"})
+    monkeypatch.setattr(organic, "get", lambda *_a, **_k: 2)
+
+    calls = {"n": 0}
+
+    def _post(*args, **kwargs):
+        calls["n"] += 1
+        return _Resp(200, {"choices": [{"message": {"content": "not valid json at all"}}]})
+
+    monkeypatch.setattr(organic.requests, "post", _post)
+    monkeypatch.setattr(organic, "sleep", lambda _s: None)
+
+    out = organic.generate_post_with_llm("activités", _minimal_source(), "guidelines")
+
+    assert out is None
+    assert calls["n"] == 1, "JSON parse errors must not trigger retries"


### PR DESCRIPTION
## Summary
Implement retry logic for `bsky organic` when OpenRouter returns `429 Too Many Requests` during LLM generation.

### Changes
- add retry loop in `generate_post_with_llm` for 429 responses
- exponential backoff between attempts (`organic.llm_retry_base_seconds`, default 3s)
- configurable retry count (`organic.llm_retry_max_retries`, default 2)
- keep explicit final failure path when retries are exhausted

### Tests
- new: `tests/test_organic_retry.py`
  - retries on 429 then succeeds
  - returns None after max retries
- regression subset:
  - `tests/test_organic_retry.py`
  - `tests/test_organic_content_types.py`
  - `tests/test_organic_threading.py`
  - `tests/test_organic_thread_posting.py`

All passing: 13/13.
