### PR TITLE
fix(runtime): enforce guard during get_follows pagination

### DIFF
--- a/bsky_cli/engage.py
+++ b/bsky_cli/engage.py
@@ -415,11 +415,19 @@ def save_state(state: dict):
     STATE_FILE.write_text(json.dumps(state, indent=2))
 
 
-def get_follows(pds: str, jwt: str, did: str) -> list[dict]:
-    """Get list of accounts we follow."""
+def get_follows(pds: str, jwt: str, did: str,
+                guard: RuntimeGuard | None = None) -> list[dict]:
+    """Get list of accounts we follow.
+
+    When *guard* is given, the runtime budget is checked between
+    pagination requests so that slow follow-list fetches don't blow
+    the ``--max-runtime-seconds`` budget.
+    """
     follows = []
     cursor = None
     while True:
+        if guard and guard.check("collect"):
+            return follows  # return partial results so caller can still save state
         params = {"actor": did, "limit": 100}
         if cursor:
             params["cursor"] = cursor
@@ -432,6 +440,9 @@ def get_follows(pds: str, jwt: str, did: str) -> list[dict]:
         r.raise_for_status()
         data = r.json()
         follows.extend(data.get("follows", []))
+        # Re-check after request (catches slow final page)
+        if guard and guard.check("collect"):
+            return follows
         cursor = data.get("cursor")
         if not cursor or len(follows) >= 500:
             break
@@ -723,7 +734,10 @@ def run(args) -> int:
     if guard.check("collect"):
         return TIMEOUT_EXIT_CODE
     print("📋 Fetching follows...")
-    follows = get_follows(pds, jwt, did)
+    follows = get_follows(pds, jwt, did, guard=guard)
+    if guard.check("collect"):
+        print(f"✓ Following {len(follows)} accounts (partial — timed out)")
+        return TIMEOUT_EXIT_CODE
     print(f"✓ Following {len(follows)} accounts")
     
     print(f"📰 Fetching recent posts (last {hours}h)...")


### PR DESCRIPTION
## Problem

`get_follows()` in `engage.py` and `appreciate.py` does not check `--max-runtime-seconds` between pagination requests. With 267 follows (3 pages at 100/page), the initial fetch can exceed the runtime budget before the per-follow `guard.check()` in the collect loop ever fires.

This was caught during integration testing (bsky-integration repo, Group C dry-run evidence).

## Fix

- `engage.get_follows()` and `appreciate.get_follows()` now accept an optional `guard` parameter
- Guard is checked before and after each pagination request
- Returns partial results on timeout (caller detects and exits cleanly)
- `run()` passes the guard and checks for timeout after `get_follows()` returns

## Tests

3 new tests in `test_runtime_bounds.py`:
- `test_engage_get_follows_respects_guard` — isolation test for engage's get_follows
- `test_appreciate_get_follows_respects_guard` — isolation test for appreciate's get_follows
- `test_engage_collect_timeout_during_get_follows_pagination` — full run() path

232/232 tests pass.

Closes #25